### PR TITLE
Empty suites and nameless suites are not excluded

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function MochaJUnitReporter(runner) {
   });
   
   runner.on('suite', function(suite){
+    if (suite.title === '' || suite.tests.length === 0) return;
     testsuites.push(this.getTestsuiteData(suite));
   }.bind(this));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-junit-reporter",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A JUnit reporter for mocha.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### Nameless Suite
The XML format doesn't support test suites with an empty, this is not allowed:
```xml
<testsuite name="">
```
However, Mocha has a **root Suite** with an empty name, as described on the [homepage](http://mochajs.org/) (search for 'root Suite'). They are now skipped in the reporting.

#### Empty Suites
Reporting for empty suites does not make sense, there's nothing to report when there are no tests. I've skipped them in the reporting as well.

#### Pull Request
This commit fixes both issues. Empty suites and nameless suites are now skipped when forming the XML.