### PR TITLE
Time and TimeStamp not matching JUnit specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err){
     testcase: [{
       _attr: {
         name: test.fullTitle(),
-        time: test.duration,
+        time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
         className: test.title
       }
     }]
@@ -97,8 +97,8 @@ MochaJUnitReporter.prototype.getXml = function(testsuites, testcases, stats){
     _suite.testsuite[0]._attr.failures = _cases.reduce(function(num, testcase){ 
       return num + (testcase.testcase.length > 1)? 1 : 0;
     }, 0);
-    _suite.testsuite[0]._attr.timestamp = stats.start;
-    _suite.testsuite[0]._attr.time = stats.duration;
+    _suite.testsuite[0]._attr.timestamp = ISODateString(stats.start);
+    _suite.testsuite[0]._attr.time =  (typeof stats.duration === 'undefined') ? 0 : stats.duration / 1000;
     return _suite;
   });
   return xml({ testsuites: suites }, { declaration: true });
@@ -112,3 +112,14 @@ MochaJUnitReporter.prototype.writeXmlToDisk = function(xml){
   fs.writeFileSync(filePath, xml, 'utf-8');
   console.log('test results written to', filePath);
 };
+
+
+function ISODateString(d) {
+  function pad(n) { return n<10 ? '0'+n : n }
+  return      d.getUTCFullYear()
+      + '-' + pad(d.getUTCMonth()+1)
+      + '-' + pad(d.getUTCDate())
+      + 'T' + pad(d.getUTCHours())
+      + ':' + pad(d.getUTCMinutes())
+      + ':' + pad(d.getUTCSeconds())
+}

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ MochaJUnitReporter.prototype.getXml = function(testsuites, testcases, stats){
     _suite.testsuite[0]._attr.failures = _cases.reduce(function(num, testcase){ 
       return num + (testcase.testcase.length > 1)? 1 : 0;
     }, 0);
-    _suite.testsuite[0]._attr.timestamp = ISODateString(stats.start);
+    _suite.testsuite[0]._attr.timestamp = stats.start.toISOString().slice(0,-5);
     _suite.testsuite[0]._attr.time =  (typeof stats.duration === 'undefined') ? 0 : stats.duration / 1000;
     return _suite;
   });
@@ -112,14 +112,3 @@ MochaJUnitReporter.prototype.writeXmlToDisk = function(xml){
   fs.writeFileSync(filePath, xml, 'utf-8');
   console.log('test results written to', filePath);
 };
-
-
-function ISODateString(d) {
-  function pad(n) { return n<10 ? '0'+n : n }
-  return      d.getUTCFullYear()
-      + '-' + pad(d.getUTCMonth()+1)
-      + '-' + pad(d.getUTCDate())
-      + 'T' + pad(d.getUTCHours())
-      + ':' + pad(d.getUTCMinutes())
-      + ':' + pad(d.getUTCSeconds())
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-junit-reporter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A JUnit reporter for mocha.",
   "main": "index.js",
   "scripts": {

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -44,7 +44,7 @@ describe('mocha-junit-reporter', function(){
     runner.emit('test end');
     runner.emit('end');
 
-    var output = fs.readFileSync(__dirname+'/test-results.xml', 'utf-8');
+    var output = fs.readFileSync(__dirname+'/mocha.xml', 'utf-8');
     expect(output).xml.to.be.valid();
     expect(output).xml.to.equal(mockXml(runner.stats));
   });

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -44,7 +44,7 @@ describe('mocha-junit-reporter', function(){
     runner.emit('test end');
     runner.emit('end');
 
-    var output = fs.readFileSync(__dirname+'/mocha.xml', 'utf-8');
+    var output = fs.readFileSync(__dirname+'/test-results.xml', 'utf-8');
     expect(output).xml.to.be.valid();
     expect(output).xml.to.equal(mockXml(runner.stats));
   });

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -8,10 +8,10 @@ module.exports = function(stats){
           {
             _attr: {
               name: "Foo Bar module",
-              timestamp: stats.start,
+              timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
               tests: "2",
               failures: "1",
-              time: stats.duration
+              time: stats.duration /1000
             }
           },
           {
@@ -19,7 +19,7 @@ module.exports = function(stats){
               _attr: {
                 name: "Foo can weez the juice",
                 className: "can weez the juice",
-                time: "1"
+                time: "0.001"
               }
             }
           },
@@ -29,7 +29,7 @@ module.exports = function(stats){
                 _attr: {
                   name: "Bar can narfle the garthog",
                   className: "can narfle the garthog",
-                  time: "1"
+                  time: "0.001"
                 }
               },
               {


### PR DESCRIPTION
# Time #
The time attribute on TestCase and TestSuite was showing the time in milliseconds but the JUnit spec requires the exectution time to be displayed in seconds.

# TimeStamp #
The timestamp attribution on TestSuite was displaying the date in a long date format (Fri May 01 2015 17:24:24 GMT+0200 (W. Europe Daylight Time)) but the the JUnit specs requires it to be ISO8601 and without milliseconds or a 'Z'

# Pull request #
In this pull request both issues mentioned above are fixed. 