### PR TITLE
Fix mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "^2.1.0",
     "chai-xml": "^0.3.0"
   },
-  "dependencies": {,
+  "dependencies": {
     "mocha": "^2.1.0",
     "xml": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^2.1.0",
-    "chai-xml": "^0.3.0",
-    "mocha": "^2.1.0"
+    "chai-xml": "^0.3.0"
   },
-  "dependencies": {
+  "dependencies": {,
+    "mocha": "^2.1.0",
     "xml": "^1.0.0"
   }
 }


### PR DESCRIPTION
Because of ```require('mocha')``` in ```index.js```, mocha needs to be included in either ```dependencies``` or ```peerDependencies``` in ```package.json``` to be used correctly.

This is especially needed when mocha is not used directly (e.g. with [gulp-mocha](https://github.com/sindresorhus/gulp-mocha)). Without this fix, the mocha-junit-reporter could only be used when mocha was installed manually by the user of this module.