### PR TITLE
Explicitly document using --reporter-options mochaFile=<path>

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ $ mocha test --reporter mocha-junit-reporter
 ```
 This will output a results file at `./test-results.xml`.
 You may optionally declare an alternate location for results XML file by setting
-the command line argument `MOCHA_FILE` or `mochaFile` in `reporterOptions`:
+the environment variable `MOCHA_FILE` or specifying `mochaFile` in `reporterOptions`:
 
 ```shell
 $ MOCHA_FILE=./path_to_your/file.xml mocha test --reporter mocha-junit-reporter
+```
+or
+```shell
+$ mocha test --reporter mocha-junit-reporter --reporter-options mochaFile=./path_to_your/file.xml
 ```
 or
 ```javascript

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -107,6 +107,15 @@ describe('mocha-junit-reporter', function() {
     verifyMochaFile(filePath);
   });
 
+  it('respects `--reporter-options mochaFile=`', function() {
+    var opts = { mochaFile: 'test/results.xml' };
+    var reporter = new Reporter(runner, { reporterOptions: opts });
+    filePath = __dirname + '/results.xml';
+
+    executeTestRunner();
+    verifyMochaFile(filePath);
+  });
+
   it('will create intermediate directories', function() {
     var reporter = new Reporter(runner, {
       reporterOptions: {mochaFile: 'test/subdir/foo/mocha.xml'}


### PR DESCRIPTION
I was a bit confused about how to specify mochaFile as a command-line argument. Turns out you don't need an environment variable! You can just pass it as a command line option.

This PR documents this in the README, and also adds a test to make sure mocha-junit-reporter continues to allow using --reporter-options.