### PR TITLE
Fix report format issues - ISSUE-16, ISSUE-17

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,6 @@ MochaJUnitReporter.prototype.getXml = function(testsuites, testcases, stats) {
     testsuites: [{
       _attr: {
         name: 'Mocha Tests',
-        timestamp: stats.start.toISOString().slice(0,-5),
         time: totalSuitesTime,
         tests: totalTests,
         failures: stats.failures

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
       _attr: {
         name: test.fullTitle(),
         time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
-        className: test.title
+        classname: test.title
       }
     }]
   };

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -8,7 +8,6 @@ module.exports = function(stats) {
           name: "Mocha Tests",
           tests: "3",
           failures: "1",
-          timestamp: stats.start.toISOString().substr(0, stats.start.toISOString().indexOf('.')),
           time: "0.006"
         }
       },

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -27,7 +27,7 @@ module.exports = function(stats) {
             testcase: {
               _attr: {
                 name: "Foo can weez the juice",
-                className: "can weez the juice",
+                classname: "can weez the juice",
                 time: "0.001"
               }
             }
@@ -37,7 +37,7 @@ module.exports = function(stats) {
               {
                 _attr: {
                   name: "Bar can narfle the garthog",
-                  className: "can narfle the garthog",
+                  classname: "can narfle the garthog",
                   time: "0.001"
                 }
               },
@@ -63,7 +63,7 @@ module.exports = function(stats) {
             testcase: {
               _attr: {
                 name: "Another suite",
-                className: "works",
+                classname: "works",
                 time: "0.004"
               }
             }


### PR DESCRIPTION
Make generated xml format match junit report spec. I'm using unit tests in https://github.com/jenkinsci/xunit-plugin/blob/master/src/test/java/org/jenkinsci/plugins/xunit/types/JUnitTypeTest.java to verify that the generated file follows junit format.