### PR TITLE
Do not ignore root suite failures.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ function MochaJUnitReporter(runner, options) {
   }.bind(this));
 
   this._runner.on('suite', function(suite) {
+    if (suite.root) {
+      suite.title = 'Root Suite';
+    }
+
     if (!isInvalidSuite(suite)) {
       testsuites.push(this.getTestsuiteData(suite));
     }

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -25,10 +25,13 @@ describe('mocha-junit-reporter', function() {
   function executeTestRunner(options) {
     options = options || {};
     options.invalidChar = options.invalidChar || '';
+    options.title = options.title || 'Foo Bar module';
+    options.root = (typeof options.root !== 'undefined') ? options.root : false;
     runner.start();
 
     runner.startSuite({
-      title: 'Foo Bar module',
+      title: options.title,
+      root: options.root,
       tests: [1, 2]
     });
 
@@ -251,6 +254,13 @@ describe('mocha-junit-reporter', function() {
 
     it('does not skip suites with nested tests', function() {
       runner.startSuite({title: 'test me', tests: [1]});
+      runner.end();
+
+      expect(testsuites).to.have.length(1);
+    });
+
+    it('does not skip root suite', function() {
+      runner.startSuite({title: '', root: true, suites: [1]});
       runner.end();
 
       expect(testsuites).to.have.length(1);


### PR DESCRIPTION
### Mocha's root-level suite hooks can fail

Mocha has a "root" suite, in which [root-level hooks](https://mochajs.org/#root-level-hooks) can be defined.  As with any other hook, these can throw a synchronous error, fail asynchronously, or time out:

```javascript
// not inside a `describe` block
before('set up some stuff', function() {
  throw new Error('failed to set stuff up');
}
```

```javascript
// not inside a `describe` block
beforeEach('set up some stuff', function(done) {
  done(new Error('failed to set stuff up'));
}
```

```javascript
// not inside a `describe` block
after('tear down some stuff', function(done) {
  this.timeout(1); // milliseconds – will fail
}
```

### `mocha-junit-reporter` dies on root hook failures
`mocha-junit-reporter` does not handle these cases gracefully.  In the case of `before`/`beforeEach`, the `fail` event handler expects some suites to have been registered where there are none, because the root suite has been [explicitly ignored](https://github.com/michaelleeallen/mocha-junit-reporter/pull/3).

```
  1) "before all" hook: open browser window
Fatal error: Cannot read property 'testsuite' of undefined
TypeError: Cannot read property 'testsuite' of undefined
  at lastSuite (.../node_modules/mocha-circleci-reporter/node_modules/mocha-junit-reporter/index.js:60:45)
  at MochaJUnitReporter.<anonymous> (.../node_modules/mocha-circleci-reporter/node_modules/mocha-junit-reporter/index.js:85:5)
  at Runner.emit (events.js:117:20)
  at Runner.fail (.../node_modules/mocha/lib/runner.js:199:8)
  at Runner.failHook (.../node_modules/mocha/lib/runner.js:224:8)
  at .../node_modules/mocha/lib/runner.js:263:14
  at Hook.done [as callback] (.../node_modules/mocha/lib/runnable.js:205:5)
  at [object Object].<anonymous> (.../node_modules/mocha/lib/runnable.js:157:10)
  at Timer.listOnTimeout [as ontimeout] (timers.js:112:15)
```

I haven't tested but I imagine the `after`/`afterEach` case would be a bit more pernicious, as the failure would end up linked to the wrong suite (whichever was last?).

As far as I can tell, this is actually a regression since https://github.com/michaelleeallen/mocha-junit-reporter/pull/25.  A quick test showed that this module reported the failure as expected before v1.9.0.

### Easy fix

This PR fixes the issue by assigning the root suite a title ("Root Suite") when encountered (Mocha provides a boolean `root` field on the suite, to recognize it), leading to its not being ignored for lack of title.  This does however lead to test counts not quite adding up as expected (i.e. failure count can be greater than test count for a given suite), but I believe this is necessary to account for what amounts to "failures" in non-tests.

cc @bobzoller