### PR TITLE
Move mocha to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "chai-xml": "^0.3.0",
-    "test-console": "^1.0.0"
+    "test-console": "^1.0.0",
+    "mocha": "^2.2.5"
   },
   "dependencies": {
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "dependencies": {
     "debug": "^2.2.0",
     "mkdirp": "~0.5.1",
-    "mocha": "^2.2.5",
     "xml": "^1.0.0"
+  },
+  "peerDependencies": {
+    "mocha": "^2.2.5",
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "xml": "^1.0.0"
   },
   "peerDependencies": {
-    "mocha": "^2.2.5",
+    "mocha": "^2.2.5"
   }
 }


### PR DESCRIPTION
This allows mocha-junit-reporter to work with mocha-mutli. Note a similar issue/resolution with mocha-cobertura-reporter.

https://github.com/jan-molak/mocha-cobertura-reporter/commit/f78771f3cb880fcf5d9331e09a8f10391615f4b3