### PR TITLE
Enable handling of test error objects without a stack property

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,8 +182,17 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     }]
   };
   if (err) {
+    var message;
+    if (err.message && typeof err.message.toString === 'function') {
+      message = err.message + '';
+    } else if (typeof err.inspect === 'function') {
+      message = err.inspect() + '';
+    } else {
+      message = '';
+    }
+    var failureMessage = err.stack || message;
     var failureElement = {
-      _cdata: this.removeInvalidCharacters(err.stack)
+      _cdata: this.removeInvalidCharacters(failureMessage)
     };
 
     config.testcase.push({failure: failureElement});

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -43,6 +43,11 @@ describe('mocha-junit-reporter', function() {
       stack: options.invalidChar + 'expected garthog to be dead' + options.invalidChar
     });
 
+    runner.fail(new Test('Baz can behave like a flandip', 'can behave like a flandip', 1), {
+      name: 'BazError',
+      message: 'expected baz to be masher, a hustler, an uninvited grasper of cone'
+    });
+
     runner.startSuite({
       title: 'Another suite!',
       tests: [1]

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -7,8 +7,8 @@ module.exports = function(stats, options) {
         _attr: {
           name: "Mocha Tests",
           tests: 3,
-          failures: "1",
-          time: "0.006"
+          failures: "2",
+          time: "0.007"
         }
       },
       {
@@ -18,8 +18,8 @@ module.exports = function(stats, options) {
               name: "Foo Bar module",
               timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
               tests: "2",
-              failures: "1",
-              time: "0.002"
+              failures: "2",
+              time: "0.003"
             }
           },
           {
@@ -42,6 +42,20 @@ module.exports = function(stats, options) {
               },
               {
                 failure: "expected garthog to be dead"
+              }
+            ]
+          },
+          {
+            testcase: [
+              {
+                _attr: {
+                  name: "Baz can behave like a flandip",
+                  classname: "can behave like a flandip",
+                  time: "0.001"
+                }
+              },
+              {
+                failure: "expected baz to be masher, a hustler, an uninvited grasper of cone"
               }
             ]
           }
@@ -73,8 +87,8 @@ module.exports = function(stats, options) {
   };
 
   if (options && options.skipPassedTests) {
-    data.testsuites[0]._attr.time = "0.005";
-    data.testsuites[1].testsuite[0]._attr.time = "0.001";
+    data.testsuites[0]._attr.time = "0.006";
+    data.testsuites[1].testsuite[0]._attr.time = "0.002";
     data.testsuites[1].testsuite.splice(1, 1);
   }
 


### PR DESCRIPTION
This is a bugfix for an issue I ran into while testing Joi validations in some async code.  Instead of using mocha's `done()` callback, I wanted to return the promise so that I would see more detailed test failure information (instead of just timeout expired).

What I ran into was that when returning a promise that throws an exception, the test's error object is the thrown error, and doesn't always have a stack property.  So my tests worked (failed and properly reported the failure info after running) with mocha's reporters, but when the mocha-junit-reporter was enabled the test process quit without giving a bad exit code or generating a report.

The change makes the error object handling more in line with how mocha's reporters work, as you can see here: https://github.com/mochajs/mocha/blob/master/lib/reporters/base.js#L171

I also added another failing test to the test suite that has a message property instead of a stack property, with appropriate Coneheads-reference test data.