### PR TITLE
add travis env variables for NPM auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ node_js:
   - '4'
 deploy:
   provider: npm
-  email: michael.lee.allen@gmail.com
-  api_key:
-    secure: YWl4mwTdJp7KI+SsFKR1JD2mBfwzVyCixuB3yOMgc8ELKF9yY766kFU5RaQzQlC4tETuLraNSNRhLMWBfAVERklA5taUgF7swioISO9YjdNumfAlwtbeKKMljV+vWPJ94r5We15Y6WysBaE0YuqG08Hy4KZ58FS+40eKsAaCnQw=
+  email: $NPM_EMAIL
+  api_key: $NPM_AUTH_KEY
   on:
     branch: master
     tags: true


### PR DESCRIPTION
This adds variables for NPM authentication. These variables are stored in the Travis environment, not here in this repo.