### PR TITLE
Fix: An invalid XML character in attribute "message"

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     var failureMessage = err.stack || message;
     var failureElement = {
       _attr: {
-        message: err.message || '',
+        message: err.message ? this.removeInvalidCharacters(err.message) : '',
         type: err.name || ''
       },
       _cdata: this.removeInvalidCharacters(failureMessage)


### PR DESCRIPTION
Fix: An invalid XML character (Unicode: 0x1b) was found in the value of attribute "message" and element is "failure" error.