### PR TITLE
Feature support for JUnit attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Here is an example of the XML output when using the `testCaseSwitchClassnameAndN
 
 You can also configure the `testsuites.name` attribute by setting `reporterOptions.testsuitesTitle` and the root suite's `name` attribute by setting `reporterOptions.rootSuiteTitle`.
 
+### Attachments
+enabling the `attachments` configuration option will allow for attaching files and screenshots in [JUnit Attachments Plugin](https://wiki.jenkins.io/display/JENKINS/JUnit+Attachments+Plugin) format.
+
+Attachment path can be injected into the test object
+```js
+it ('should include attachment', function () {
+  this.test.attachments = ['/absolut/path/to/file.png'];
+});
+```
+
 ### Full configuration options
 
 | Parameter | Effect |
@@ -124,3 +134,4 @@ You can also configure the `testsuites.name` attribute by setting `reporterOptio
 | testCaseSwitchClassnameAndName | set to a truthy value to switch name and classname values |
 | rootSuiteTitle | the name for the root suite. (defaults to 'Root Suite') |
 | testsuitesTitle | the name for the `testsuites` tag (defaults to 'Mocha Tests') |
+| attachments | if set to truthy value will attach files to report in `JUnit Attachments Plugin` format |

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function configureDefaults(options) {
   options = options.reporterOptions || {};
   options.mochaFile = options.mochaFile || process.env.MOCHA_FILE || 'test-results.xml';
   options.properties = options.properties || parsePropertiesFromEnv(process.env.PROPERTIES) || null;
+  options.attachments = options.attachments || process.env.ATTACHMENTS || false;
   options.toConsole = !!options.toConsole;
   options.testCaseSwitchClassnameAndName = options.testCaseSwitchClassnameAndName || false;
   options.suiteTitleSeparedBy = options.suiteTitleSeparedBy || ' ';
@@ -186,7 +187,7 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
 MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   var flipClassAndName = this._options.testCaseSwitchClassnameAndName;
   var name = stripAnsi(test.fullTitle());
-  var classname = stripAnsi(test.title)
+  var classname = stripAnsi(test.title);
   var config = {
     testcase: [{
       _attr: {
@@ -196,6 +197,14 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
       }
     }]
   };
+
+  if (this._options.attachments && test.attachments && test.attachments.length > 0) {
+    config.testcase.push({'system-out': test.attachments.map(
+      function (file) {
+        return '[[ATTACHMENT|' + file + ']]';
+      }
+    ).join('\n')});
+  }
 
   if (err) {
     var message;

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -271,6 +271,74 @@ describe('mocha-junit-reporter', function() {
 
   });
 
+  describe('when "attachments" option is specified', function() {
+    it('adds attachments to xml report', function() {
+      var reporter = createReporter({attachments: true});
+      var suite = {title: 'with attachments', tests: [1]};
+      var test = new Test('has attachment', 'included attachment', 1);
+      var filePath = '/path/to/file';
+      var testsuites;
+      var xml;
+      runner.startSuite(suite);
+      test.attachments = [filePath];
+      runner.pass(test);
+      reporter.flush = function(suites) {
+        testsuites = suites;
+      };
+      runner.end();
+      expect(testsuites[0].testsuite[0]._attr.name).to.equal(suite.title);
+      expect(testsuites[0].testsuite[1].testcase).to.have.length(2);
+      expect(testsuites[0].testsuite[1].testcase[0]._attr.name).to.equal(test.fullTitle());
+      expect(testsuites[0].testsuite[1].testcase[1]).to.have.property('system-out', '[[ATTACHMENT|' + filePath + ']]');
+      xml = reporter.getXml(testsuites);
+
+      expect(xml).to.include('<system-out>[[ATTACHMENT|' + filePath + ']]</system-out>');
+    });
+
+    it('does not add system-out if no attachments were passed', function() {
+      var reporter = createReporter({attachments: true});
+      var suite = {title: 'with attachments', tests: [1]};
+      var test = new Test('has attachment', 'included attachment', 1);
+      var filePath = '/path/to/file';
+      var testsuites;
+      var xml;
+      runner.startSuite(suite);
+      runner.pass(test);
+      reporter.flush = function(suites) {
+        testsuites = suites;
+      };
+      runner.end();
+      expect(testsuites[0].testsuite[0]._attr.name).to.equal(suite.title);
+      expect(testsuites[0].testsuite[1].testcase).to.have.length(1);
+      expect(testsuites[0].testsuite[1].testcase[0]._attr.name).to.equal(test.fullTitle());
+      xml = reporter.getXml(testsuites);
+
+      expect(xml).to.not.include('<system-out>[[ATTACHMENT|' + filePath + ']]</system-out>');
+    });
+
+    it('does not add system-out if no attachments array is empty', function() {
+      var reporter = createReporter({attachments: true});
+      var suite = {title: 'with attachments', tests: [1]};
+      var test = new Test('has attachment', 'included attachment', 1);
+      var filePath = '/path/to/file';
+      var testsuites;
+      var xml;
+      test.attachments = [];
+      runner.startSuite(suite);
+      runner.pass(test);
+      reporter.flush = function(suites) {
+        testsuites = suites;
+      };
+      runner.end();
+      expect(testsuites[0].testsuite[0]._attr.name).to.equal(suite.title);
+      expect(testsuites[0].testsuite[1].testcase).to.have.length(1);
+      expect(testsuites[0].testsuite[1].testcase[0]._attr.name).to.equal(test.fullTitle());
+      xml = reporter.getXml(testsuites);
+
+      expect(xml).to.not.include('<system-out>[[ATTACHMENT|' + filePath + ']]</system-out>');
+    });
+  });
+
   describe('Output', function() {
     var reporter, testsuites;
 
@@ -361,34 +429,34 @@ describe('mocha-junit-reporter', function() {
   });
 
   describe('Feature "Configurable classname/name switch"', function() {
-    var reporter, testsuites, mockedTestCase = {
+    var reporter, mockedTestCase = {
       title: "should behave like so",
       timestamp: 123,
       tests: "1",
       failures: "0",
       time: "0.004",
       fullTitle: function() {
-        return 'Super Suite ' + this.title
+        return 'Super Suite ' + this.title;
       }
     };
 
     it('should generate valid testCase for testCaseSwitchClassnameAndName default', function() {
       reporter = createReporter({mochaFile: 'test/mocha.xml'});
-      var testCase = reporter.getTestcaseData(mockedTestCase)
+      var testCase = reporter.getTestcaseData(mockedTestCase);
       expect(testCase.testcase[0]._attr.name).to.equal(mockedTestCase.fullTitle());
       expect(testCase.testcase[0]._attr.classname).to.equal(mockedTestCase.title);
     });
 
     it('should generate valid testCase for testCaseSwitchClassnameAndName=false', function() {
       reporter = createReporter({mochaFile: 'test/mocha.xml', testCaseSwitchClassnameAndName: false});
-      var testCase = reporter.getTestcaseData(mockedTestCase)
+      var testCase = reporter.getTestcaseData(mockedTestCase);
       expect(testCase.testcase[0]._attr.name).to.equal(mockedTestCase.fullTitle());
       expect(testCase.testcase[0]._attr.classname).to.equal(mockedTestCase.title);
     });
 
     it('should generate valid testCase for testCaseSwitchClassnameAndName=true', function() {
       reporter = createReporter({mochaFile: 'test/mocha.xml', testCaseSwitchClassnameAndName: true});
-      var testCase = reporter.getTestcaseData(mockedTestCase)
+      var testCase = reporter.getTestcaseData(mockedTestCase);
       expect(testCase.testcase[0]._attr.name).to.equal(mockedTestCase.title);
       expect(testCase.testcase[0]._attr.classname).to.equal(mockedTestCase.fullTitle());
     });


### PR DESCRIPTION
Allow adding attachments in [JUnit attachments plugin](https://wiki.jenkins.io/display/JENKINS/JUnit+Attachments+Plugin) format