### PR TITLE
Add an option to include test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,54 @@ Here is an example of the XML output when using the `testCaseSwitchClassnameAndN
 
 You can also configure the `testsuites.name` attribute by setting `reporterOptions.testsuitesTitle` and the root suite's `name` attribute by setting `reporterOptions.rootSuiteTitle`.
 
+### System out and system err
+The JUnit format defines a pair of tags - `<system-out/>` and `<system-err/>` - for describing a test's generated output
+and error streams, respectively. It is possible to pass the test outputs/errors as an array of text lines:
+```js
+it ('should report output', function () {
+  this.test.consoleOutputs = [ 'line 1 of output', 'line 2 of output' ];
+});
+it ('should report error', function () {
+  this.test.consoleErrors = [ 'line 1 of errors', 'line 2 of errors' ];
+});
+```
+
+Since this module is only a reporter and not a self-contained test runner, it does not perform
+output capture itself. Thus, the author of the tests is responsible for providing a mechanism
+via which the outputs/errors array will be populated.
+
+If capturing only console.log/console.error is an option, a simple (if a bit hack-ish) solution is to replace
+the implementations of these functions globally, like so:
+```js
+var util = require('util');
+
+describe('my console tests', function () {
+  var originalLogFunction = console.log;
+  var originalErrorFunction = console.error;
+  beforeEach(function _mockConsoleFunctions() {
+    var currentTest = this.currentTest;
+    console.log = function captureLog() {
+      var formattedMessage = util.format.apply(util, arguments);
+      currentTest.consoleOutputs = (currentTest.consoleOutputs || []).concat(formattedMessage);
+    };
+    console.error = function captureError() {
+      var formattedMessage = util.format.apply(util, arguments);
+      currentTest.consoleErrors = (currentTest.consoleErrors || []).concat(formattedMessage);
+    };
+  });
+  afterEach(function _restoreConsoleFunctions() {
+    console.log = originalLogFunction;
+    console.error = originalErrorFunction;
+  });
+  it('should output something to the console', function() {
+    // This should end up in <system-out>:
+    console.log('hello, %s', 'world');
+  });
+});
+```
+
+Remember to run with `--reporter-options outputs=true` if you want test outputs in XML.
+
 ### Attachments
 enabling the `attachments` configuration option will allow for attaching files and screenshots in [JUnit Attachments Plugin](https://wiki.jenkins.io/display/JENKINS/JUnit+Attachments+Plugin) format.
 
@@ -119,6 +167,14 @@ Attachment path can be injected into the test object
 it ('should include attachment', function () {
   this.test.attachments = ['/absolut/path/to/file.png'];
 });
+```
+
+If both attachments and outputs are enabled, and a test injects both consoleOutputs and attachments, then
+the XML output will look like the following:
+```xml
+<system-out>output line 1
+output line 2
+[[ATTACHMENT|path/to/file]]</system-out>
 ```
 
 ### Full configuration options
@@ -134,4 +190,5 @@ it ('should include attachment', function () {
 | testCaseSwitchClassnameAndName | set to a truthy value to switch name and classname values |
 | rootSuiteTitle | the name for the root suite. (defaults to 'Root Suite') |
 | testsuitesTitle | the name for the `testsuites` tag (defaults to 'Mocha Tests') |
-| attachments | if set to truthy value will attach files to report in `JUnit Attachments Plugin` format |
+| outputs | if set to truthy value will include console output and console error output |
+| attachments | if set to truthy value will attach files to report in `JUnit Attachments Plugin` format (after console outputs, if any) |

--- a/index.js
+++ b/index.js
@@ -198,12 +198,25 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     }]
   };
 
+  // We need to merge console.logs and attachments into one <system-out> -
+  //  see JUnit schema (only accepts 1 <system-out> per test).
+  var systemOutLines = [];
+  if (this._options.outputs && (test.consoleOutputs && test.consoleOutputs.length > 0)) {
+    systemOutLines = systemOutLines.concat(test.consoleOutputs);
+  }
   if (this._options.attachments && test.attachments && test.attachments.length > 0) {
-    config.testcase.push({'system-out': test.attachments.map(
+    systemOutLines = systemOutLines.concat(test.attachments.map(
       function (file) {
         return '[[ATTACHMENT|' + file + ']]';
       }
-    ).join('\n')});
+    ));
+  }
+  if (systemOutLines.length > 0) {
+    config.testcase.push({'system-out': systemOutLines.join('\n')});
+  }
+
+  if (this._options.outputs && (test.consoleErrors && test.consoleErrors.length > 0)) {
+    config.testcase.push({'system-err': test.consoleErrors.join('\n')});
   }
 
   if (err) {


### PR DESCRIPTION
This change allows test authors to manually inject test outputs (`system-out` and `system-err`) into the XML output. It leaves it to the author to come up with a way to assemble the outputs, and suggests a way in the README by mocking `console.log` and friends. It also plays nice with attachments by outputting them as before, one per line, after the actual output (if any).

For #48 