### PR TITLE
Ant and jenkins modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JUnit Reporter for Mocha
 
-[![Build Status](https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master)](https://travis-ci.org/michaelleeallen/mocha-junit-reporter)
-[![npm](https://img.shields.io/npm/v/mocha-junit-reporter.svg?maxAge=2592000)](https://www.npmjs.com/package/mocha-junit-reporter)
+[![Build Status](travis-badge)](travis-build)
+[![npm](npm-badge)](npm-listing)
 
 Produces JUnit-style XML test results.
 
@@ -47,7 +47,7 @@ var mocha = new Mocha({
 
 You can also add properties to the report under `testsuite`. This is useful if you want your CI environment to add extra build props to the report for analytics purposes
 
-```
+```xml
 <testsuites>
   <testsuite>
     <properties>
@@ -104,10 +104,10 @@ var mocha = new Mocha({
 
 Here is an example of the XML output when using the `testCaseSwitchClassnameAndName` option:
 
-| value | XML output |
-|----------------------------------|--------|
-| `true`                           | `<testcase name="should behave like so" classname="Super Suite should behave like so">` |
-| `false` (default)                | `<testcase name="Super Suite should behave like so" classname="should behave like so">` |
+| value             | XML output |
+|-------------------|------------|
+| `true`            | `<testcase name="should behave like so" classname="Super Suite should behave like so">` |
+| `false` (default) | `<testcase name="Super Suite should behave like so" classname="should behave like so">` |
 
 You can also configure the `testsuites.name` attribute by setting `reporterOptions.testsuitesTitle` and the root suite's `name` attribute by setting `reporterOptions.rootSuiteTitle`.
 
@@ -192,3 +192,12 @@ output line 2
 | testsuitesTitle | the name for the `testsuites` tag (defaults to 'Mocha Tests') |
 | outputs | if set to truthy value will include console output and console error output |
 | attachments | if set to truthy value will attach files to report in `JUnit Attachments Plugin` format (after console outputs, if any) |
+| antMode | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema] |
+| antHostname | hostname to use when running in `antMode`  will default to environment `HOSTNAME` |
+
+
+[travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
+[travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter
+[npm-badge]: https://img.shields.io/npm/v/mocha-junit-reporter.svg?maxAge=2592000
+[npm-listing]: https://www.npmjs.com/package/mocha-junit-reporter
+[ant-schema]: http://windyroad.org/dl/Open%20Source/JUnit.xsd

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ output line 2
 | attachments | if set to truthy value will attach files to report in `JUnit Attachments Plugin` format (after console outputs, if any) |
 | antMode | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema] |
 | antHostname | hostname to use when running in `antMode`  will default to environment `HOSTNAME` |
-
+| jenkinsMode | if set to truthy value will return xml that will display nice results in Jenkins |
 
 [travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
 [travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function updateOptionsForJenkinsMode(options) {
   if (options.useFullSuiteTitle === undefined) {
     options.useFullSuiteTitle = true;
   }
+  debug('jenkins mode - testCaseSwitchClassnameAndName', options.testCaseSwitchClassnameAndName);
   if (options.testCaseSwitchClassnameAndName === undefined) {
     options.testCaseSwitchClassnameAndName = true;
   }
@@ -112,25 +113,31 @@ function isInvalidSuite(suite) {
 
 function parsePropertiesFromEnv(envValue) {
   if (envValue) {
+    debug('Parsing from env', envValue);
     return envValue.split(',').reduce(function(properties, prop) {
       var property = prop.split(':');
       properties[property[0]] = property[1];
       return properties;
-    });
+    }, []);
   }
 
   return null;
 }
 
 function generateProperties(options) {
-  return Object.keys(options.properties).reduce(function(properties, name) {
-    var value = options.properties[name];
+  var props = options.properties;
+  if (!props) {
+    return [];
+  }
+  return Object.keys(props).reduce(function(properties, name) {
+    var value = props[name];
     properties.push({ property: { _attr: { name: name, value: value } } });
     return properties;
   }, []);
 }
 
 function getJenkinsClassname (test) {
+  debug('Building jenkins classname for', test);
   var parent = test.parent;
   var titles = [];
   while (parent) {
@@ -227,9 +234,9 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
   if (antMode) {
     _attr.package = _attr.name;
     _attr.hostname = this._options.antHostname;
-    _attr.id = this._antID;
+    _attr.id = this._antId;
     _attr.errors = 0;
-    this._antID += 1;
+    this._antId += 1;
   }
 
   return testSuite;

--- a/index.js
+++ b/index.js
@@ -65,21 +65,22 @@ function updateOptionsForJenkinsMode(options) {
 
 /**
  * Determine an option value.
- * 1. If `value` is specified, then use that value
- * 2. If `key` is present in the environment, then use the environment value
+ * 1. If `key` is present in the environment, then use the environment value
+ * 2. If `value` is specified, then use that value
  * 3. Fall back to `defaultVal`
  * @module mocha-junit-reporter
  * @param {Object} value - the value from the reporter options
  * @param {String} key - the environment variable to check
  * @param {Object} defaultVal - the fallback value
+ * @param {function} transform - a transformation function to be used when loading values from the environment
  */
 function getSetting(value, key, defaultVal, transform) {
-  if (value !== undefined) {
-    return value;
-  }
   if (process.env[key] !== undefined) {
     var envVal = process.env[key];
     return (typeof transform === 'function') ? transform(envVal) : envVal;
+  }
+  if (value !== undefined) {
+    return value;
   }
   return defaultVal;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chai": "^3.0.0",
     "chai-xml": "^0.3.0",
     "eslint": "^4.0.0",
+    "libxmljs": "^0.19.5",
     "mocha": "^3.0.0",
     "test-console": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai-xml": "^0.3.0",
     "eslint": "^4.0.0",
     "libxmljs": "^0.19.5",
-    "mocha": "^3.0.0",
+    "mocha": "^5.0.0",
     "test-console": "^1.0.0"
   },
   "dependencies": {

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -621,8 +621,9 @@ describe('mocha-junit-reporter', function() {
       ];
 
       it('generates Jenkins compatible classnames and suite name', function() {
-        var reporter = configureReporter({jenkinsMode: true }, suites);
+        var reporter = configureReporter({jenkinsMode: true}, suites);
 
+        debug('testcase', reporter.suites[0].testsuite[1].testcase[0])
         expect(reporter.suites[0].testsuite[0]._attr.name).to.equal(suites[0].testsuite.title);
         expect(reporter.suites[0].testsuite[1].testcase[0]._attr.name).to.equal(suites[0].pass[0].title);
         expect(reporter.suites[0].testsuite[1].testcase[0]._attr.classname).to.equal(suites[0].testsuite.title);

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -269,7 +269,6 @@ describe('mocha-junit-reporter', function() {
 
       return reporter;
     }
-
   });
 
   describe('when "outputs" option is specified', function() {
@@ -599,6 +598,38 @@ describe('mocha-junit-reporter', function() {
       xmlDoc.validate(xsdDoc);
 
       expect(xmlDoc.validationErrors).to.be.deep.equal([]);
+    });
+
+    describe('Jenkins format', function () {
+      var suites = [
+        {
+          testsuite: {
+            title: 'Inner Suite',
+            suites: [1],
+            tests: [1]
+          },
+          pass: [ {title: 'test', fullTitle: 'Inner Suite test'} ],
+          suites: [ {
+            testsuite: {
+              title: 'Another Suite',
+              suites: [1],
+              tests: [1]
+            },
+            fail: [ {title: 'fail test', fullTitle: 'Another Suite fail test', error: new Error('failed test')}]
+          } ]
+        },
+      ];
+
+      it('generates Jenkins compatible classnames and suite name', function() {
+        var reporter = configureReporter({jenkinsMode: true }, suites);
+
+        expect(reporter.suites[0].testsuite[0]._attr.name).to.equal(suites[0].testsuite.title);
+        expect(reporter.suites[0].testsuite[1].testcase[0]._attr.name).to.equal(suites[0].pass[0].title);
+        expect(reporter.suites[0].testsuite[1].testcase[0]._attr.classname).to.equal(suites[0].testsuite.title);
+        expect(reporter.suites[1].testsuite[0]._attr.name).to.equal(suites[0].testsuite.title + '.' + suites[0].suites[0].testsuite.title);
+        expect(reporter.suites[1].testsuite[1].testcase[0]._attr.name).to.equal(suites[0].suites[0].fail[0].title);
+        expect(reporter.suites[1].testsuite[1].testcase[0]._attr.classname).to.equal(suites[0].testsuite.title + '.' + suites[0].suites[0].testsuite.title);
+      });
     });
 
     function configureReporter(options, suites) {

--- a/test/resources/JUnit.xsd
+++ b/test/resources/JUnit.xsd
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	 elementFormDefault="qualified"
+	 attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the GNU Lesser General Public License (LGPL) http://www.gnu.org/licenses/lgpl.html
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+	</xs:annotation>
+	<xs:element name="testsuite" type="testsuite"/>
+	<xs:simpleType name="ISO8601_DATETIME_PATTERN">
+		<xs:restriction base="xs:dateTime">
+			<xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="testsuites">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="testsuite">
+								<xs:attribute name="package" type="xs:token" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="id" type="xs:int" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="testsuite">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="properties">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:token">
+											<xs:minLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="value" type="xs:string" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:choice minOccurs="0">
+						<xs:element name="error">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+			</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="failure">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+			</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="pre-string">
+										<xs:attribute name="message" type="xs:string">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="type" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+											</xs:annotation>
+										</xs:attribute>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="name" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="classname" type="xs:token" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="time" type="xs:decimal" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="system-out">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="system-err">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="pre-string">
+						<xs:whiteSpace value="preserve"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="hostname" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:token">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="tests" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="failures" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="errors" type="xs:int" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">The total number of tests in the suite that errorrd. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="time" type="xs:decimal" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="pre-string">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/test/resources/jenkins-junit.xsd
+++ b/test/resources/jenkins-junit.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+ 
+ This file available under the terms of the the MIT License as follows:
+ 
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>


### PR DESCRIPTION
@yonjah I've combined #74 and #75 in this PR. I've somehow broken one of the Jenkins tests, I hope to fix it tomorrow.

I have slightly changed the behavior of your `deduceConfig` function. The search order is now `config -> env -> default` instead of `env -> config -> default`. If you have a good argument for the older behavior, please share it. Otherwise please validate that I've faithfully merged your work in here.

Closes #70 
Closes #71 
Closes #74
Closes #75