### PR TITLE
Update getJenkinsClassname() to use suiteTitleSeparedBy option

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function generateProperties(options) {
   }, []);
 }
 
-function getJenkinsClassname (test) {
+function getJenkinsClassname (test, options) {
   debug('Building jenkins classname for', test);
   var parent = test.parent;
   var titles = [];
@@ -163,7 +163,7 @@ function getJenkinsClassname (test) {
     parent.title && titles.unshift(parent.title);
     parent = parent.parent;
   }
-  return titles.join('.');
+  return titles.join(options.suiteTitleSeparatedBy);
 }
 
 /**
@@ -273,7 +273,7 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
 MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   var jenkinsMode = this._options.jenkinsMode;
   var flipClassAndName = this._options.testCaseSwitchClassnameAndName;
-  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test) : test.fullTitle());
+  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test, this._options) : test.fullTitle());
   var classname = stripAnsi(test.title);
   var testcase = {
     testcase: [{


### PR DESCRIPTION
The current `getJenkinsClassname()` method currently joins the class names by a `.`. This change updates it to use the configured `suiteTitleSeparedBy` value.

This is not a breaking change as the `suiteTitleSeparedBy` option defaults to `.` when `jenkinsMode` is set to `true`