### PR TITLE
jenkinsClassnamePrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ output line 2
 | antMode | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema] |
 | antHostname | hostname to use when running in `antMode`  will default to environment `HOSTNAME` |
 | jenkinsMode | if set to truthy value will return xml that will display nice results in Jenkins |
+| jenkinsClassnamePrefix | adds a prefix to classname. Useful for grouping tests in packages. |
 
 [travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
 [travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function configureDefaults(options) {
   options.toConsole = !!options.toConsole;
   options.rootSuiteTitle = options.rootSuiteTitle || 'Root Suite';
   options.testsuitesTitle = options.testsuitesTitle || 'Mocha Tests';
+  options.jenkinsClassnamePrefix = options.jenkinsClassnamePrefix || '';
 
   if (options.antMode) {
     updateOptionsForAntMode(options);
@@ -155,7 +156,7 @@ function generateProperties(options) {
   }, []);
 }
 
-function getJenkinsClassname (test) {
+function getJenkinsClassname (test, options) {
   debug('Building jenkins classname for', test);
   var parent = test.parent;
   var titles = [];
@@ -163,7 +164,7 @@ function getJenkinsClassname (test) {
     parent.title && titles.unshift(parent.title);
     parent = parent.parent;
   }
-  return titles.join('.');
+  return options.jenkinsClassnamePrefix + titles.join('.');
 }
 
 /**
@@ -273,7 +274,7 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
 MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   var jenkinsMode = this._options.jenkinsMode;
   var flipClassAndName = this._options.testCaseSwitchClassnameAndName;
-  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test) : test.fullTitle());
+  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test, this._options) : test.fullTitle());
   var classname = stripAnsi(test.title);
   var testcase = {
     testcase: [{


### PR DESCRIPTION
This option allows to group tests under the package name. For example if `jenkinsClassnamePrefix = "cypress."`. Then all cypress tests would be placed under the `cypress` package. The dot (`.`) will work as a classname separator.

It is very useful for monorepos where user can have multiple test cases/runners etc. Right now, when there is no package everything land in (root) which is not very useful.

Example:

Now (without the prefix option) - all test cases with single classname (without dot) will land under (root)
![image](https://user-images.githubusercontent.com/3865478/67266763-42e1e500-f4b1-11e9-858b-def2f499e11a.png)

With prefix we can group tests together:
![image](https://user-images.githubusercontent.com/3865478/67266815-5f7e1d00-f4b1-11e9-9521-ec175f816179.png)
