### PR TITLE
Fixed unhandled promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     var failureMessage = err.stack || message;
     var failureElement = {
       _attr: {
-        message: this.removeInvalidCharacters(err.message) || '',
+        message: this.removeInvalidCharacters(message) || '',
         type: err.name || ''
       },
       _cdata: this.removeInvalidCharacters(failureMessage)


### PR DESCRIPTION
I'm running on node v12.13.0, npm 6.12.0, mocha 6.2.2 and mocha-junit-reporter 1.23.1.

When running mocha like 'mocha --no-timeout --reporter mocha-junit-reporter test/tests.js' if there's a test case that fails, instead of the test proceeding to the next case, it crashes with unhandled promise rejection caused by the removeInvalidCharacters method. The problem was resolved with making sure the proper string variable gets passed to the function call.

Error log:
![promise_rejection](https://user-images.githubusercontent.com/15691900/67479766-6e0e3500-f667-11e9-920b-a4ce3c7a1ba1.png)
