### PR TITLE
Add a diff between err.actual & err.expected to test case failure data 

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,10 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     } else {
       message = '';
     }
-    var diff = !Base.hideDiff && Base.showDiff(err)
+    var diff = !Base.hideDiff
+        && typeof Base.showDiff === 'function'
+        && typeof Base.generateDiff === 'function'
+        && Base.showDiff(err)
       ? '\n' + Base.generateDiff(err.actual, err.expected)
       : '';
     var failureMessage = (err.stack || message) + diff;

--- a/index.js
+++ b/index.js
@@ -337,7 +337,10 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     } else {
       message = '';
     }
-    var failureMessage = err.stack || message;
+    var diff = !Base.hideDiff && Base.showDiff(err)
+      ? '\n' + Base.generateDiff(err.actual, err.expected)
+      : '';
+    var failureMessage = (err.stack || message) + diff;
     var failureElement = {
       _attr: {
         message: this.removeInvalidCharacters(message) || '',


### PR DESCRIPTION
This PR adds a diff between actual & expected values to `<failure>` when mocha v6+ is used to speed up troubleshooting of test failures on CI environment.