### PR TITLE
Testsuite time should include setup and teardown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,32 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@sinonjs/fake-timers": "^6.0.1",
     "chai": "^3.0.0",
     "chai-xml": "^0.3.0",
     "eslint": "^7.0.0",

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -10,7 +10,7 @@ module.exports = function(stats, options) {
           name: "Mocha Tests",
           tests: 4,
           failures: "2",
-          time: "432.1100"
+          time: ((stats.duration || 0) / 1000).toFixed(4)
         }
       },
       {
@@ -18,7 +18,7 @@ module.exports = function(stats, options) {
           {
             _attr: {
               name: "Root Suite",
-              timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
+              timestamp: "1970-01-01T00:00:00", // ISO timestamp truncated to the second
               tests: "0",
               failures: "0",
               time: "0.0000"
@@ -31,10 +31,10 @@ module.exports = function(stats, options) {
           {
             _attr: {
               name: "Foo Bar",
-              timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
+              timestamp: "1970-01-01T00:00:00",
               tests: "3",
               failures: "2",
-              time: "32.1060"
+              time: "100.0010"
             }
           },
           {
@@ -93,10 +93,10 @@ module.exports = function(stats, options) {
           {
             _attr: {
               name: "Another suite!",
-              timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
+              timestamp: "1970-01-01T00:01:40", // new Date(100001).toISOString().slice(0, -5)
               tests: "1",
               failures: "0",
-              time: "400.0040"
+              time: "400.0050"
             }
           },
           {
@@ -144,7 +144,7 @@ module.exports = function(stats, options) {
         {
           _attr: {
             name: "Pending suite!",
-            timestamp: stats.start.toISOString().substr(0,stats.start.toISOString().indexOf('.')),
+            timestamp: "1970-01-01T00:08:20", // new Date(100001 + 400005).toISOString().slice(0, -5)
             tests: "1",
             failures: "0",
             skipped: "1",


### PR DESCRIPTION
The `time` attribute on `testsuite` should equal the amount of time
between the runner issuing the `suite` and `end suite` events.
It was previously calculated as the sum of each individual testcase's
`time`, but that doesn't account for setup and teardown.

Similarly, total time for all testsuites should be the amount of
time between the `start` and `end` events, which the `Base` reporter
stores in `stats.duration` for us.

Fixes #114