### PR TITLE
Turn on linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
-script: npm test
+script: npm run ci
 deploy:
   provider: npm
   email: $NPM_EMAIL

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A JUnit reporter for mocha.",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint index.js test/*; exit 0",
+    "ci": "npm run lint && npm run test",
+    "lint": "./node_modules/.bin/eslint index.js test/*",
     "test": "MOCHA_FILE=test/mocha.xml node_modules/.bin/mocha test --reporter=spec",
     "tdd": "MOCHA_FILE=test/mocha.xml node_modules/.bin/mocha test --reporter=min --watch"
   },

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -623,7 +623,7 @@ describe('mocha-junit-reporter', function() {
       it('generates Jenkins compatible classnames and suite name', function() {
         var reporter = configureReporter({jenkinsMode: true}, suites);
 
-        debug('testcase', reporter.suites[0].testsuite[1].testcase[0])
+        debug('testcase', reporter.suites[0].testsuite[1].testcase[0]);
         expect(reporter.suites[0].testsuite[0]._attr.name).to.equal(suites[0].testsuite.title);
         expect(reporter.suites[0].testsuite[1].testcase[0]._attr.name).to.equal(suites[0].pass[0].title);
         expect(reporter.suites[0].testsuite[1].testcase[0]._attr.classname).to.equal(suites[0].testsuite.title);


### PR DESCRIPTION
For some reason, linting wasn't run in the build and `npm lint` was configured to always return success.

![image](https://user-images.githubusercontent.com/610129/81477030-39b52d00-91e3-11ea-8f96-3d69e23eee7f.png)

Also added a `ci` command since that's what most CI servers (including Travis) will run by default.