### PR TITLE
Add Node 12 and 14 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
+  - "14"
 script: npm test
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "12"
-  - "14"
+node_js: ["10", "12", "14"]
 script: npm test
 deploy:
   provider: npm


### PR DESCRIPTION
Node 12 has been LTS since Oct. 2019. Node 14 will be LTS later this year.