### PR TITLE
Drop support for old Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
 script: npm test
 deploy:


### PR DESCRIPTION
Node 6 and 8 have long passed end of life.

This is a breaking change, so it would require a major version bump.