### PR TITLE
Fix strict mode declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,14 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "node": true
-    },
-    "extends": "eslint:recommended",
-    "rules": {
-      "no-extra-semi": "warn",
-      "semi": ["error", "always"],
-      "space-in-parens": ["error", "never"],
-      "space-infix-ops": "error"
-    }
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "no-extra-semi": "warn",
+    "semi": ["error", "always"],
+    "space-in-parens": ["error", "never"],
+    "space-infix-ops": "error",
+    "strict": "error"
+  }
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use-strict';
+'use strict';
 
 var xml = require('xml');
 var Base = require('mocha').reporters.Base;

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-'use-strict';
+'use strict';
 
 var Reporter = require('../index');
 var Runner = require('./helpers/mock-runner');

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var xml = require('xml');
 
 module.exports = function(stats, options) {


### PR DESCRIPTION
There were a bunch of `'use-strict'` annotations which as far as I know isn't a thing. This also turns on eslint checks for strict mode to catch this in the future.