### PR TITLE
Update jenkins mode to use suiteTitleSeparatedBy and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ var mocha = new Mocha({
     reporter: 'mocha-junit-reporter',
     reporterOptions: {
         testsuitesTitle: true,
-        suiteTitleSeparatedBy: '.' // suites separator, default is space (' ')
+        suiteTitleSeparatedBy: '.' // suites separator, default is space (' '), or period ('.') in jenkins mode
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ output line 2
 | properties                     | `null`                 | a hash of additional properties to add to each test suite                                                               |
 | toConsole                      | `false`                | if set to a truthy value the produced XML will be logged to the console                                                 |
 | useFullSuiteTitle              | `false`                | if set to a truthy value nested suites' titles will show the suite lineage                                              |
-| suiteTitleSeparedBy            | ` ` (space)            | the character to use to separate nested suite titles. (defaults to ' ')                                                 |
+| suiteTitleSeparatedBy          | ` ` (space)            | the character to use to separate nested suite titles. (defaults to ' ', '.' if in jenkins mode)                         |
+| suiteTitleSeparedBy            | ` ` (space)            | deprecated. use `suiteTitleSeparatedBy`                                                                                 |
 | testCaseSwitchClassnameAndName | `false`                | set to a truthy value to switch name and classname values                                                               |
 | rootSuiteTitle                 | `Root Suite`           | the name for the root suite. (defaults to 'Root Suite')                                                                 |
 | testsuitesTitle                | `Mocha Tests`          | the name for the `testsuites` tag (defaults to 'Mocha Tests')                                                           |

--- a/index.js
+++ b/index.js
@@ -76,8 +76,7 @@ function configureDefaults(options) {
     updateOptionsForJenkinsMode(config);
   }
 
-  config.suiteTitleSeparedBy = config.suiteTitleSeparedBy || ' ';
-  config.suiteTitleSeparatedBy = config.suiteTitleSeparatedBy || config.suiteTitleSeparedBy;
+  config.suiteTitleSeparatedBy = config.suiteTitleSeparatedBy || config.suiteTitleSeparedBy || ' ';
 
   return config;
 }
@@ -98,8 +97,8 @@ function updateOptionsForJenkinsMode(options) {
   if (options.testCaseSwitchClassnameAndName === undefined) {
     options.testCaseSwitchClassnameAndName = true;
   }
-  if (options.suiteTitleSeparedBy === undefined) {
-    options.suiteTitleSeparedBy = '.';
+  if (options.suiteTitleSeparatedBy === undefined) {
+    options.suiteTitleSeparatedBy = '.';
   }
 }
 
@@ -177,7 +176,7 @@ function generateProperties(options) {
   }, []);
 }
 
-function getJenkinsClassname (test) {
+function getJenkinsClassname (test, options) {
   debug('Building jenkins classname for', test);
   var parent = test.parent;
   var titles = [];
@@ -185,7 +184,7 @@ function getJenkinsClassname (test) {
     parent.title && titles.unshift(parent.title);
     parent = parent.parent;
   }
-  return titles.join('.');
+  return titles.join(options.suiteTitleSeparatedBy);
 }
 
 /**
@@ -295,7 +294,7 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
 MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   var jenkinsMode = this._options.jenkinsMode;
   var flipClassAndName = this._options.testCaseSwitchClassnameAndName;
-  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test) : test.fullTitle());
+  var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test, this._options) : test.fullTitle());
   var classname = stripAnsi(test.title);
   var testcase = {
     testcase: [{


### PR DESCRIPTION
Updating https://github.com/michaelleeallen/mocha-junit-reporter/pull/93

The current getJenkinsClassname() method currently joins the class names by a `.`. This change updates it to use the configured `suiteTitleSeparatedBy` value.

This is not a breaking change as the `suiteTitleSeparatedBy` option defaults to . when jenkinsMode is set to true

This also updates the documentation to use the correct `suiteTitleSeparatedBy` by and call out that `suiteTitleSeparedBy` is deprecated