### PR TITLE
Protect against mocked Dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ var mkdirp = require('mkdirp');
 var md5 = require('md5');
 var stripAnsi = require('strip-ansi');
 
+// capture global Date object before it's monkey-patched by timekeeper or otherwise mocked.
+var Date = global.Date;
+
 var createStatsCollector;
 var mocha6plus;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,6 +1740,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+      "dev": true
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "^7.2.0",
     "rimraf": "^3.0.2",
     "test-console": "^1.0.0",
+    "timekeeper": "^2.2.0",
     "xmllint": "^0.1.1"
   },
   "dependencies": {


### PR DESCRIPTION
Mocking the native Date class (for example with the timekeeper module), is common during tests. This change ensures that report timestamps are correctly recorded even if the test suite is doing some "time traveling".