### PR TITLE
Add diff printing support

### DIFF
--- a/index.js
+++ b/index.js
@@ -338,6 +338,12 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
       message = '';
     }
     var failureMessage = err.stack || message;
+    if (!Base.hideDiff && err.expected !== undefined) {
+        var oldUseColors = Base.useColors;
+        Base.useColors = false;
+        failureMessage += "\n" + Base.generateDiff(err.actual, err.expected);
+        Base.useColors = oldUseColors;
+    }
     var failureElement = {
       _attr: {
         message: this.removeInvalidCharacters(message) || '',

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -322,6 +322,26 @@ describe('mocha-junit-reporter', function() {
     });
   });
 
+  it('properly diffs errors from Chai', function(done) {
+    var reporter = createReporter();
+    var rootSuite = reporter.runner.suite;
+    var suite1 = Suite.create(rootSuite, 'failing with Chai');
+    suite1.addTest(createTest('test 1', function () {
+      expect({}).to.deep.equal({missingProperty: true});
+    }));
+
+    runRunner(reporter.runner, function() {
+      reporter.runner.dispose();
+      expect(reporter._testsuites).to.have.lengthOf(2);
+      expect(reporter._testsuites[1].testsuite[0]._attr.name).to.equal('failing with Chai');
+      expect(reporter._testsuites[1].testsuite[1].testcase).to.have.lengthOf(2);
+      expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.name).to.equal('failing with Chai test 1');
+      expect(reporter._testsuites[1].testsuite[1].testcase[1].failure._attr.message).to.equal('expected {} to deeply equal { missingProperty: true }');
+      expect(reporter._testsuites[1].testsuite[1].testcase[1].failure._cdata).to.match(/AssertionError: expected {} to deeply equal {\s*missingProperty:\s*true\s*}\n(?:\s* at .*? \(.*?\)\n)*\n\s*\+ expected - actual\n\s*-{}\n\s*\+{\n\s*\+\s*"missingProperty":\s*true\n\s*\+}[\s\S]*/);
+      done();
+    });
+  });
+
   describe('when "useFullSuiteTitle" option is specified', function() {
     it('generates full suite title', function(done) {
       var reporter = createReporter({useFullSuiteTitle: true });


### PR DESCRIPTION
If a library (say, Chai) throws an AssertionError, Mocha will typically print the diff for you with most reporters. This PR adds diff functionality to mocha-junit-reporter.