### PR TITLE
feature | allow to add jenkinsClassnamePrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ output line 2
 | antMode                        | `false`                | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema]                                        |
 | antHostname                    | `process.env.HOSTNAME` | hostname to use when running in `antMode`  will default to environment `HOSTNAME`                                       |
 | jenkinsMode                    | `false`                | if set to truthy value will return xml that will display nice results in Jenkins                                        |
+| jenkinsClassnamePrefix         | `undefined`            | adds a prefix to a classname when running  in `jenkinsMode`                                                             |
 
 [travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
 [travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter

--- a/index.js
+++ b/index.js
@@ -184,6 +184,9 @@ function getJenkinsClassname (test, options) {
     parent.title && titles.unshift(parent.title);
     parent = parent.parent;
   }
+  if (options.jenkinsClassnamePrefix) {
+    titles.unshift(options.jenkinsClassnamePrefix);
+  }
   return titles.join(options.suiteTitleSeparatedBy);
 }
 

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -699,6 +699,29 @@ describe('mocha-junit-reporter', function() {
           done();
         });
       });
+      it('prefix is added to a classname when jenkinsClassnamePrefix is specified', function(done) {
+        var reporter = createReporter({jenkinsMode: true,  jenkinsClassnamePrefix: "Added Prefix"});
+        var rootSuite = reporter.runner.suite;
+
+        var suite1 = Suite.create(rootSuite, 'Inner Suite');
+        suite1.addTest(createTest('test'));
+
+        var suite2 = Suite.create(suite1, 'Another Suite');
+        suite2.addTest(createTest('fail test', function(done) {
+          done(new Error('failed test'));
+        }));
+
+        runRunner(reporter.runner, function() {
+          expect(reporter._testsuites[0].testsuite[0]._attr.name).to.equal('');
+          expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.name).to.equal('test');
+          expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.classname).to.equal('Added Prefix.Inner Suite');
+          expect(reporter._testsuites[2].testsuite[0]._attr.name).to.equal('Root Suite.Inner Suite.Another Suite');
+          expect(reporter._testsuites[2].testsuite[1].testcase[0]._attr.name).to.equal('fail test');
+          expect(reporter._testsuites[2].testsuite[1].testcase[0]._attr.classname).to.equal('Added Prefix.Inner Suite.Another Suite');
+
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Hi, please allow to set prefixes in Jenkins 

this PR is similar to https://github.com/michaelleeallen/mocha-junit-reporter/pull/94 , but it doesn't require to explicitly add '.' to the end of `jenkinsClassnamePrefix`