### PR TITLE
add support for linking tests to Jira issues (e.g. stories, requirements), using Xray

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
 
   var requirement = (test._testConfig !== undefined) ? test._testConfig['requirement'] : test.fn['requirement'];
   if (requirement !== undefined) {
-	testcase['testcase'][0]['_attr']['req'] = requirement;
+	testcase['testcase'][0]['_attr']['requirement'] = requirement;
   } 
   //console.log(test);
 

--- a/index.js
+++ b/index.js
@@ -328,9 +328,6 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
         name: flipClassAndName ? classname : name,
         time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
         classname: flipClassAndName ? name : classname
-	//requirement: 'xpto'
-	//req: test._testConfig['tags']
-	//req: test._testConfig['requirement']
       }
     }]
   };
@@ -339,7 +336,6 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   if (requirement !== undefined) {
 	testcase['testcase'][0]['_attr']['requirement'] = requirement;
   } 
-  //console.log(test);
 
   // We need to merge console.logs and attachments into one <system-out> -
   //  see JUnit schema (only accepts 1 <system-out> per test).

--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     }]
   };
 
-  var requirement = (test._testConfig !== undefined) ? test._testConfig['requirement'] : undefined;
+  var requirement = (test._testConfig !== undefined) ? test._testConfig['requirement'] : test.fn['requirement'];
   if (requirement !== undefined) {
 	testcase['testcase'][0]['_attr']['req'] = requirement;
   } 

--- a/index.js
+++ b/index.js
@@ -328,9 +328,18 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
         name: flipClassAndName ? classname : name,
         time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
         classname: flipClassAndName ? name : classname
+	//requirement: 'xpto'
+	//req: test._testConfig['tags']
+	//req: test._testConfig['requirement']
       }
     }]
   };
+
+  var requirement = (test._testConfig !== undefined) ? test._testConfig['requirement'] : undefined;
+  if (requirement !== undefined) {
+	testcase['testcase'][0]['_attr']['req'] = requirement;
+  } 
+  //console.log(test);
 
   // We need to merge console.logs and attachments into one <system-out> -
   //  see JUnit schema (only accepts 1 <system-out> per test).


### PR DESCRIPTION
This PR adds support for "linking" mocha tests to existing  Jira issue, such as user stories, right from the test code.
For that, users just need to add a "requirement" attribute on the "it" block, specifying the Jira issue key to link that test to.
This  ultimately will add a "requirement" attribute on the generated JUnit XML report that can be processed by Xray (https://www.getxray.app/), a well-known test management tool for Jira, whenever the report is submitted to it.

The code was tested with basic mocha tests and also using Cypress (which uses mocha).
This will benefit many teams using Jira and Xray and doesnt interfere with existing behaviour.

**Example of how to link a test to a user story, having the issue key CALC-123, using just mocha:**

```
var assert = require('assert');
describe('Array', function() {
  describe('#indexOf()', function() {
    it('should return -1 when the value is not present', { requirement: 'CALC-123' }, function() {
      assert.equal([1, 2, 3].indexOf(4), -1);
    });

    it('should return >= 0 when the value ispresent', { tags: 'CALC2' }, function() {
      assert.equal([1, 2, 3].indexOf(1), 0);
    });


  });
});
```

**Example of how to link a test to a user story, having the issue key CALC-123, using Cypress:**


```
describe('My second test', function() {
  it('Gets, types and asserts', { requirement: 'CALC-123' }, function() {
    cy.visit('https://example.cypress.io')

    cy.contains('type').click()

    // Should be on a new URL which includes '/commands/actions'
    cy.url().should('include', '/commands/actions')

    // Get an input, type into it and verify that the value has been updated
    cy.get('.action-email')
      .type('fake@email.com')
      .should('have.value', 'fake@email.com') // error added on the test itself just to make it fail
  })
})
```

