### PR TITLE
Fix test failures when running on older versions of mocha

### DIFF
--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -365,13 +365,16 @@ describe('mocha-junit-reporter', function() {
     }));
 
     runRunner(reporter.runner, function() {
-      reporter.runner.dispose();
+      if (reporter.runner.dispose) {
+        reporter.runner.dispose();
+      }
+
       expect(reporter._testsuites).to.have.lengthOf(2);
       expect(reporter._testsuites[1].testsuite[0]._attr.name).to.equal('failing with Chai');
       expect(reporter._testsuites[1].testsuite[1].testcase).to.have.lengthOf(2);
       expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.name).to.equal('failing with Chai test 1');
       expect(reporter._testsuites[1].testsuite[1].testcase[1].failure._attr.message).to.equal('expected {} to deeply equal { missingProperty: true }');
-      expect(reporter._testsuites[1].testsuite[1].testcase[1].failure._cdata).to.match(/AssertionError: expected {} to deeply equal {\s*missingProperty:\s*true\s*}\n(?:\s* at .*? \(.*?\)\n)*\n\s*\+ expected - actual\n\s*-{}\n\s*\+{\n\s*\+\s*"missingProperty":\s*true\n\s*\+}[\s\S]*/);
+      expect(reporter._testsuites[1].testsuite[1].testcase[1].failure._cdata).to.match(/AssertionError: expected {} to deeply equal {\s*missingProperty:\s*true\s*}\n(?:\s* at .*?\n)*\n\s*\+ expected - actual\n+\s*-{}\n\s*\+{\n\s*\+\s*"missingProperty":\s*true\n\s*\+}[\s\S]*/);
       done();
     });
   });


### PR DESCRIPTION
Introduced by #157. No idea how that build passed.