### PR TITLE
More placeholders in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ var mocha = new Mocha({
 
 ### Results Report
 
-Results XML filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].xml`. `[hash]` is replaced by MD5 hash of test results XML. This enables support of parallel execution of multiple `mocha-junit-reporter`'s writing test results in separate files.
+Results XML filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].xml`. `[hash]` is replaced by MD5 hash of test results XML. This enables support of parallel execution of multiple `mocha-junit-reporter`'s writing test results in separate files. In addition to this there are these placeholders can also be used:
+
+| placeholder         | output                                            |
+| ------------------- | ------------------------------------------------- |
+| `[testsuitesTitle]` | will be replaced by the `testsuitesTitle` setting |
+| `[rootSuiteTitle]`  | will be replaced by the `rootSuiteTitle` setting  |
+| `[suiteFilename]`   | will be replaced by the filename of the spec file |
+| `[suiteName]`       | will be replaced by the name the first test suite |
+
 
 In order to display full suite title (including parents) just specify `testsuitesTitle` option
 ```javascript

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ var mocha = new Mocha({
 
 ### Results Report
 
-Results XML filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].xml`. `[hash]` is replaced by MD5 hash of test results XML. This enables support of parallel execution of multiple `mocha-junit-reporter`'s writing test results in separate files. In addition to this there are these placeholders can also be used:
+Results XML filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].xml`. `[hash]` is replaced by MD5 hash of test results XML. This enables support of parallel execution of multiple `mocha-junit-reporter`'s writing test results in separate files. In addition to this these placeholders can also be used:
 
 | placeholder         | output                                            |
 | ------------------- | ------------------------------------------------- |

--- a/index.js
+++ b/index.js
@@ -399,14 +399,44 @@ MochaJUnitReporter.prototype.removeInvalidCharacters = function(input){
  */
 MochaJUnitReporter.prototype.flush = function(testsuites){
   this._xml = this.getXml(testsuites);
+  
+  var reportFilename = this.formatReportFilename(this._xml, testsuites);
 
-  this.writeXmlToDisk(this._xml, this._options.mochaFile);
+  this.writeXmlToDisk(this._xml, reportFilename);
 
   if (this._options.toConsole === true) {
     console.log(this._xml); // eslint-disable-line no-console
   }
 };
 
+/**
+ * Formats the report filename by replacing placeholders
+ * @param {string} xml - xml string
+ * @param {Array.<Object>} testsuites - a list of xml configs
+ */
+MochaJUnitReporter.prototype.formatReportFilename = function(xml, testsuites) {
+
+  var reportFilename = this._options.mochaFile;
+
+  if (reportFilename.indexOf('[hash]') !== -1) {
+    reportFilename = reportFilename.replace('[hash]', md5(xml));
+  }
+
+  if (reportFilename.indexOf('[testsuitesTitle]') !== -1) {
+    reportFilename = reportFilename.replace('[testsuitesTitle]', this._options.testsuitesTitle);
+  }
+  if (reportFilename.indexOf('[rootSuiteTitle]') !== -1) {
+    reportFilename = reportFilename.replace('[rootSuiteTitle]', this._options.rootSuiteTitle);
+  }
+  if (reportFilename.indexOf('[suiteFilename]') !== -1) {
+    reportFilename = reportFilename.replace('[suiteFilename]', testsuites[0].testsuite[0]._attr.file);
+  }
+  if (reportFilename.indexOf('[suiteName]') !== -1) {
+    reportFilename = reportFilename.replace('[suiteName]', testsuites[1].testsuite[0]._attr.name);
+  }
+
+  return reportFilename;
+}
 
 /**
  * Produces an XML string from the given test data.
@@ -491,10 +521,6 @@ MochaJUnitReporter.prototype.getXml = function(testsuites) {
  */
 MochaJUnitReporter.prototype.writeXmlToDisk = function(xml, filePath){
   if (filePath) {
-    if (filePath.indexOf('[hash]') !== -1) {
-      filePath = filePath.replace('[hash]', md5(xml));
-    }
-
     debug('writing file to', filePath);
     mkdirp.sync(path.dirname(filePath));
 

--- a/index.js
+++ b/index.js
@@ -436,7 +436,7 @@ MochaJUnitReporter.prototype.formatReportFilename = function(xml, testsuites) {
   }
 
   return reportFilename;
-}
+};
 
 /**
  * Produces an XML string from the given test data.

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -275,6 +275,68 @@ describe('mocha-junit-reporter', function() {
     });
   });
 
+
+  it("respects `[testsuitesTitle]` pattern in test results report filename", function (done) {
+    var dir = "test/output/";
+    var path = dir + "results.[testsuitesTitle].xml";
+    var reporter = createReporter({ mochaFile: path });
+    runTests(reporter, function () {
+      verifyMochaFile(
+        reporter.runner,
+        dir + "results." + reporter._options.testsuitesTitle + ".xml"
+      );
+      done();
+    });
+  });
+
+  it("respects `[rootSuiteTitle]` pattern in test results report filename", function (done) {
+    var dir = "test/output/";
+    var path = dir + "results.[rootSuiteTitle].xml";
+    var reporter = createReporter({ mochaFile: path });
+    runTests(reporter, function () {
+      verifyMochaFile(
+        reporter.runner,
+        dir +
+          "results." +
+          reporter._testsuites[0].testsuite[0]._attr.name +
+          ".xml"
+      );
+      done();
+    });
+  });
+
+  it("respects `[suiteFilename]` pattern in test results report filename", function (done) {
+    var dir = "test/output/";
+    var path = dir + "results.[suiteFilename].xml";
+    var reporter = createReporter({ mochaFile: path });
+    runTests(reporter, function () {
+      verifyMochaFile(
+        reporter.runner,
+        dir +
+          "results." +
+          reporter._testsuites[0].testsuite[0]._attr.file +
+          ".xml"
+      );
+      done();
+    });
+  });
+
+  it("respects `[suiteName]` pattern in test results report filename", function (done) {
+    var dir = "test/output/";
+    var path = dir + "results.[suiteName].xml";
+    var reporter = createReporter({ mochaFile: path });
+    runTests(reporter, function () {
+      verifyMochaFile(
+        reporter.runner,
+        dir +
+          "results." +
+          reporter._testsuites[1].testsuite[0]._attr.name +
+          ".xml"
+      );
+      done();
+    });
+  });
+
   it('will create intermediate directories', function(done) {
     var reporter = createReporter({mochaFile: 'test/output/foo/mocha.xml'});
     runTests(reporter, function() {


### PR DESCRIPTION
Adding more options to the placeholders for generating report files

| placeholder         | output                                            |
| ------------------- | ------------------------------------------------- |
| `[testsuitesTitle]` | will be replaced by the `testsuitesTitle` setting |
| `[rootSuiteTitle]`  | will be replaced by the `rootSuiteTitle` setting  |
| `[suiteFilename]`   | will be replaced by the filename of the spec file |
| `[suiteName]`       | will be replaced by the name the first test suite |

see requests in : 
https://github.com/michaelleeallen/mocha-junit-reporter/issues/144
https://github.com/michaelleeallen/mocha-junit-reporter/issues/132