### PR TITLE
Invalid version check for mocha 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ try {
   var json = JSON.parse(
     fs.readFileSync(path.dirname(require.resolve('mocha')) + "/package.json", "utf8")
   );
-  var version = json.version;
-  if (version >= "6") {
+  var version = json.version && json.version.split('.')[0];
+  if (version >= 6) {
     createStatsCollector = require("mocha/lib/stats-collector");
     mocha6plus = true;
   } else {


### PR DESCRIPTION
The version check in index.js is not valid for mocha 10+

``` index.js

 var version = json.version;
  if (version >= "6") {
    createStatsCollector = require("mocha/lib/stats-collector");
    mocha6plus = true;
  } else {
    mocha6plus = false;
  }
```

This will break the stats collector. Other functions work fine. 

