### PR TITLE
Property support for test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,29 @@ output line 2
 [[ATTACHMENT|path/to/file]]</system-out>
 ```
 
+### Properties for test cases
+Properties can be attached to test objects as follows:
+
+```js
+it ('should include properties', function () {
+  this.test.properties = [
+    { name: 'author', value: 'User' },
+    { name: 'priority', value: 'high' },
+    { name: 'description', value: 'Multi-line properties with text values..', text: true },
+  ];
+});
+```
+
+Test case properties are useful to include additional meta information with tests that are displayed by various CI services and testing tools. Properties are included in the XML output under `testcase` elements like this:
+
+```xml
+<properties>
+  <property name="author" value="User"/>
+  <property name="priority" value="high"/>
+  <property name="description"><![CDATA[Multi-line properties with text values..]]></property>
+</properties>
+```
+
 ### Full configuration options
 
 | Parameter                      | Default                | Effect                                                                                                                  |

--- a/index.js
+++ b/index.js
@@ -356,6 +356,30 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
     testcase.testcase.push({'system-err': this.removeInvalidCharacters(stripAnsi(test.consoleErrors.join('\n')))});
   }
 
+  if (test.properties && test.properties.length > 0) {
+    var properties = test.properties.map(function(property) {
+      if (property.text) {
+        return {
+          property: {
+            _attr: { name: this.removeInvalidCharacters(property.name) },
+            _cdata: this.removeInvalidCharacters(property.value)
+          }
+        };
+      } else {
+        return {
+          property: {
+            _attr: {
+              name: this.removeInvalidCharacters(property.name),
+              value: this.removeInvalidCharacters(property.value)
+            }
+          }
+        };
+      }
+    }, this);
+
+    testcase.testcase.push({'properties': properties});
+  }
+
   if (err) {
     var message;
     if (err.message && typeof err.message.toString === 'function') {


### PR DESCRIPTION
This PR adds optional support for properties on a test case level as discussed in #183. This allows developers & testers to include additional metadata and properties that are then displayed by various CI and testing tools. It uses the exact format as already supported by many tools. Summary of this PR:

* Fully backwards compatible: if no properties are specified, nothing is output (no need for additional options)
* It uses the same API style as the existing `this.test.attachments` and `this.test.consoleOutputs` APIs
* It uses the standard `<property>` format as used for `<testsuite>`, and works the same as other frameworks with test case property support (such as Pytest and Playwright)
* This is intentionally a small code change only so it is easy to review and merge
* I've tested this with various other tools to make sure it works well in various scenarios