### PR TITLE
patch: Update package.json to match lock file from dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "md5": "^2.3.0",
-    "mkdirp": "~1.0.4",
+    "mkdirp": "~1.2.6",
     "strip-ansi": "^6.0.1",
     "xml": "^1.0.1"
   },


### PR DESCRIPTION
https://github.com/michaelleeallen/mocha-junit-reporter/pull/166 this pr only updates the lockfile and not the package.json so the offending package version for minimist is still installed