### PR TITLE
Add "propertiesFile" for custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,28 @@ var mocha = new Mocha({
 })
 ```
 
+You can also alternatively use the config `propertyFile` to use a javascript file instead which should return a object containing the properties.
+
+```javascript
+// testProperties.js
+module.exports = (suite) => {
+  return {
+    name: suite.name,
+    file: suite.file,
+    custom_property: custom_value
+  }
+}
+```
+
+```javascript
+var mocha = new Mocha({
+    reporter: 'mocha-junit-reporter',
+    reporterOptions: {
+        propertiesFile: 'testProperties.js'
+    }
+})
+```
+
 ### Results Report
 
 Results XML filename can contain `[hash]`, e.g. `./path_to_your/test-results.[hash].xml`. `[hash]` is replaced by MD5 hash of test results XML. This enables support of parallel execution of multiple `mocha-junit-reporter`'s writing test results in separate files. In addition to this these placeholders can also be used:

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -621,6 +621,64 @@ describe('mocha-junit-reporter', function() {
     });
   });
 
+  describe('when "propertiesFile" option is specified',function(){
+    it('use properties from the file', function(done){
+      var reporter = createReporter({propertiesFile: __dirname + '/mock-test-properties.js',mochaFile: 'test/output/mocha.xml'});
+      runTests(reporter, function() {
+        verifyMochaFile(reporter.runner, filePath, {
+          properties: [
+            {
+              name: 'CUSTOM_PROPERTY_FROM_FILE',
+              value: 'XYZ~321'
+            }
+          ]
+        });
+        done();
+      });
+    });
+
+    it('wrong file name should be ignored', function(done){
+      var reporter = createReporter({propertiesFile: 'wrong-file-directory',mochaFile: 'test/output/mocha.xml'});
+      runTests(reporter, function() {
+        verifyMochaFile(reporter.runner, filePath);
+        done();
+      });
+    });
+
+    it('wrong file name should not effect config.properties', function(done){
+      process.env.PROPERTIES = 'CUSTOM_PROPERTY:ABC~123';
+      var reporter = createReporter({propertiesFile: 'wrong-file-directory',mochaFile: 'test/output/mocha.xml'});
+      runTests(reporter, function() {
+        verifyMochaFile(reporter.runner, filePath, {
+          properties: [
+            {
+              name: 'CUSTOM_PROPERTY',
+              value: 'ABC~123'
+            }
+          ]
+        });
+        done();
+      });
+    });
+
+    it('config.properties to override config.propertiesFile', function(done){
+      process.env.PROPERTIES = 'CUSTOM_PROPERTY:ABC~123';
+      var reporter = createReporter({propertiesFile: __dirname + '/mock-test-properties.js' ,mochaFile: 'test/output/mocha.xml'});
+      runTests(reporter, function() {
+        verifyMochaFile(reporter.runner, filePath, {
+          properties: [
+            {
+              name: 'CUSTOM_PROPERTY',
+              value: 'ABC~123'
+            }
+          ]
+        });
+        done();
+      });
+    });
+
+  });
+
   describe('Output', function() {
     it('skips suites with empty title', function(done) {
       var reporter = createReporter();

--- a/test/mock-test-properties.js
+++ b/test/mock-test-properties.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = () => {
+  return {
+    CUSTOM_PROPERTY_FROM_FILE: 'XYZ~321'
+  };
+};


### PR DESCRIPTION
Adds a new configuration option called "propertiesFile" which lets you configure properties using a javascript file. This file should export a function which then accepts "testsuite" as a parameter and returns a object. This is then attached to the respective testsuite.

Replicates: https://github.com/jest-community/jest-junit#adding-custom-testcase-properties